### PR TITLE
Add basic noVNC remote desktop client

### DIFF
--- a/components/apps/RemoteDesktop/StyledRemoteDesktop.ts
+++ b/components/apps/RemoteDesktop/StyledRemoteDesktop.ts
@@ -1,0 +1,21 @@
+import styled from "styled-components";
+
+const StyledRemoteDesktop = styled.div`
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+
+  .controls {
+    display: flex;
+    gap: 4px;
+    padding: 2px;
+    background: rgba(0, 0, 0, 0.1);
+  }
+
+  .screen {
+    flex: 1;
+    background: #000;
+  }
+`;
+
+export default StyledRemoteDesktop;

--- a/components/apps/RemoteDesktop/index.tsx
+++ b/components/apps/RemoteDesktop/index.tsx
@@ -1,0 +1,23 @@
+import { useRef } from "react";
+import StyledRemoteDesktop from "components/apps/RemoteDesktop/StyledRemoteDesktop";
+import useRemoteDesktop from "components/apps/RemoteDesktop/useRemoteDesktop";
+import { type ComponentProcessProps } from "components/system/Apps/RenderComponent";
+import Button from "styles/common/Button";
+
+const RemoteDesktop: FC<ComponentProcessProps> = ({ id }) => {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const { containerRef, connect, disconnect } = useRemoteDesktop(id);
+
+  return (
+    <StyledRemoteDesktop ref={containerRef}>
+      <div className="controls">
+        <input ref={inputRef} placeholder="wss://host:port" />
+        <Button onClick={() => connect(inputRef.current?.value || "")}>Connect</Button>
+        <Button onClick={disconnect}>Disconnect</Button>
+      </div>
+      <div className="screen" />
+    </StyledRemoteDesktop>
+  );
+};
+
+export default RemoteDesktop;

--- a/components/apps/RemoteDesktop/useRemoteDesktop.ts
+++ b/components/apps/RemoteDesktop/useRemoteDesktop.ts
@@ -1,0 +1,52 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useProcesses } from "contexts/process";
+import type RFB from "@novnc/novnc/core/rfb";
+
+const REMOTE_LIB =
+  "https://cdn.jsdelivr.net/npm/@novnc/novnc@1.4.0/core/rfb.js";
+
+type UseRemoteDesktopReturn = {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  connect: (url: string) => Promise<void>;
+  disconnect: () => void;
+};
+
+const useRemoteDesktop = (id: string): UseRemoteDesktopReturn => {
+  const { argument } = useProcesses();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const rfbRef = useRef<RFB>();
+
+  const connect = useCallback(
+    async (url: string): Promise<void> => {
+      if (containerRef.current && url) {
+        const { default: RFB } = (await import(
+          /* webpackIgnore: true */ REMOTE_LIB
+        )) as { default: typeof RFB };
+
+        const screen = containerRef.current.querySelector(
+          ".screen"
+        ) as HTMLElement;
+        rfbRef.current = new RFB(screen, url);
+        argument(id, "connected", true);
+      }
+    },
+    [argument, id]
+  );
+
+  const disconnect = useCallback(() => {
+    rfbRef.current?.disconnect();
+    rfbRef.current = undefined;
+    argument(id, "connected", false);
+  }, [argument, id]);
+
+  useEffect(() => {
+    argument(id, "connect", connect);
+    argument(id, "disconnect", disconnect);
+
+    return disconnect;
+  }, [argument, connect, disconnect, id]);
+
+  return { containerRef, connect, disconnect };
+};
+
+export default useRemoteDesktop;

--- a/contexts/process/directory.ts
+++ b/contexts/process/directory.ts
@@ -385,6 +385,16 @@ const directory: Processes = {
     ],
     title: "Video Player",
   },
+  RemoteDesktop: {
+    Component: dynamic(() => import("components/apps/RemoteDesktop")),
+    backgroundColor: "#000",
+    defaultSize: {
+      height: 600,
+      width: 800,
+    },
+    icon: "/System/Icons/pc.webp",
+    title: "Remote Desktop",
+  },
   Vim: {
     Component: dynamic(() => import("components/apps/Vim")),
     allowResizing: false,

--- a/contexts/process/types.ts
+++ b/contexts/process/types.ts
@@ -39,6 +39,12 @@ type PdfProcessArguments = {
   subTitle?: string;
 };
 
+type RemoteDesktopProcessArguments = {
+  connect?: (url: string) => void;
+  connected?: boolean;
+  disconnect?: () => void;
+};
+
 export type RelativePosition = {
   bottom?: number;
   left?: number;
@@ -70,7 +76,8 @@ export type ProcessArguments = BaseProcessArguments &
   DialogProcessArguments &
   MediaPlayerProcessArguments &
   MonacoProcessArguments &
-  PdfProcessArguments;
+  PdfProcessArguments &
+  RemoteDesktopProcessArguments;
 
 export type ProcessElements = {
   componentWindow?: HTMLElement;


### PR DESCRIPTION
## Summary
- introduce `RemoteDesktop` app for VNC connections
- expose connect/disconnect in process state
- register new process in directory
- extend process types for remote desktop

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_6841f603b7f48325b71868350eccfbd6